### PR TITLE
feat: Add confirm modal to avoid delete meetings by mistake

### DIFF
--- a/src/app-lib/components/modals/ConfirmModal.tsx
+++ b/src/app-lib/components/modals/ConfirmModal.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 interface ConfirmModalProps {
   isOpen: boolean;
   onClose: () => void;

--- a/src/app-lib/hooks/projects/useProjectDetail.ts
+++ b/src/app-lib/hooks/projects/useProjectDetail.ts
@@ -17,6 +17,7 @@ export const useProjectDetail = (project?: Project) => {
   const [updateSuccessMsg, setUpdateSuccessMsg] = useState("");
   const [showMeetingModal, setShowMeetingModal] = useState(false);
   const [isDeletingMeetings, setIsDeletingMeetings] = useState(false);
+  const [showDeleteConfirmModal, setShowDeleteConfirmModal] = useState(false);
 
   // Ejemplo: si quisieras eliminar todo el proyecto desde acá, podrías
   // meterlo en un "useProjectActions.ts" con removeProject() y llamarlo aquí.
@@ -38,8 +39,19 @@ export const useProjectDetail = (project?: Project) => {
     setUpdateSuccessMsg(message);
   };
 
-  const handleDeleteAllMeetings = async () => {
+  const handleDeleteMeetingsClick = () => {
+    setShowDeleteConfirmModal(true);
+  };
+
+  const handleCancelDeleteMeetings = () => {
+    setShowDeleteConfirmModal(false);
+  };
+
+  const handleConfirmDeleteMeetings = async () => {
     if (!project?.id) return;
+    
+    setShowDeleteConfirmModal(false);
+    
     try {
       setIsDeletingMeetings(true);
 
@@ -74,9 +86,12 @@ export const useProjectDetail = (project?: Project) => {
     showMeetingModal,
     setShowMeetingModal,
     isDeletingMeetings,
+    showDeleteConfirmModal,
     handleEdit,
     handleCancelEdit,
     handleSaveSuccess,
-    handleDeleteAllMeetings,
+    handleDeleteMeetingsClick,
+    handleCancelDeleteMeetings,
+    handleConfirmDeleteMeetings,
   };
 };

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -7,6 +7,7 @@ import ProjectForm from "@/smartspecs/app-lib/components/forms/ProjectForm";
 import MeetingList from "@/smartspecs/app-lib/components/lists/MeetingList";
 import ProjectInfo from "./components/ProjectInfo";
 import Modal from "@/smartspecs/app-lib/components/modals/Modal";
+import ConfirmModal from "@/smartspecs/app-lib/components/modals/ConfirmModal";
 import LoadingSpinner from "@/smartspecs/app-lib/components/common/LoadingSpinner";
 import ErrorMessage from "@/smartspecs/app-lib/components/messages/ErrorMessage";
 import SuccessMessage from "@/smartspecs/app-lib/components/messages/SuccessMessage";
@@ -47,8 +48,11 @@ const ProjectDetail: React.FC = () => {
     handleSaveSuccess,
     showMeetingModal,
     setShowMeetingModal,
-    handleDeleteAllMeetings,
+    handleDeleteMeetingsClick,
+    handleCancelDeleteMeetings,
+    handleConfirmDeleteMeetings,
     isDeletingMeetings,
+    showDeleteConfirmModal,
   } = useProjectDetail(project);
 
   const [showCopySuccess, setShowCopySuccess] = useState(false);
@@ -220,7 +224,7 @@ const ProjectDetail: React.FC = () => {
             </button>
             <button
               className="bg-red-500 text-white px-4 py-2 rounded"
-              onClick={handleDeleteAllMeetings}
+              onClick={handleDeleteMeetingsClick}
               disabled={isDeletingMeetings}
             >
               {isDeletingMeetings ? (
@@ -288,6 +292,17 @@ const ProjectDetail: React.FC = () => {
           onSend={handleSendSelectedRequirements}
         />
       </Modal>
+
+      <ConfirmModal
+        isOpen={showDeleteConfirmModal}
+        onClose={handleCancelDeleteMeetings}
+        onConfirm={handleConfirmDeleteMeetings}
+        title="Delete All Meetings"
+        message="Are you sure you want to delete all meetings from this project? This action cannot be undone."
+        confirmText="Delete All"
+        cancelText="Cancel"
+        confirmButtonStyle="danger"
+      />
 
       <div className="bg-background p-6 rounded-xl shadow-md w-full mt-8">
         <h2 className="text-2xl font-bold mb-4">Meetings</h2>


### PR DESCRIPTION
**Summary**

Implements a confirmation modal before executing the "Delete All Meetings" operation to prevent accidental data loss from user mistakes.

**Changes Made**

UI/UX Improvements:
✅ Added confirmation dialog before deleting all meetings
✅ Clear warning message: "This action cannot be undone"
✅ Red danger-styled confirm button for visual warning
✅ Two-step process: Click button → Confirm action

**Code Changes:**

useProjectDetail.ts: Refactored delete logic into three separate handlers:
- handleDeleteMeetingsClick() - Opens confirmation modal
- handleCancelDeleteMeetings() - Cancels operation
- handleConfirmDeleteMeetings() - Executes deletion after confirmation

projects/[id]/page.tsx: Integrated ConfirmModal component with appropriate props

ConfirmModal.tsx: Added missing React import